### PR TITLE
Making modifications to run target and disease oriented searches para…

### DIFF
--- a/OTAR_result_parser/OTAR_result_parser.py
+++ b/OTAR_result_parser/OTAR_result_parser.py
@@ -132,7 +132,7 @@ def main():
             analysisResult[queryType]['target-disease-pairs'].apply(lambda row: print(
                 'Assoc #{} - Target ID: {}, disease ID: {}, association score: {}'.format(row.name, row['target.id'],
                                                                       row['disease.id'],row['association_score.overall'])),
-                 axis=1)           
+                 axis=1)
         else:
             print('\n[Warning] {} as {} ID returned no association.'.format(analysisResult[queryType]['queryTerm'], queryType))
 
@@ -145,7 +145,7 @@ def main():
             print('\tThe maximum of the association_score.overall values: {}'.format(analysisResult[queryType]['score_max']))
             print('\tThe minimum of the association_score.overall values: {}'.format(analysisResult[queryType]['score_min']))
             print('\tThe average of the association_score.overall values: {}'.format(analysisResult[queryType]['score_mean']))
-            print('\tThe standard error of the association_score.overall values: {}'.format(analysisResult[queryType]['score_std']))         
+            print('\tThe standard error of the association_score.overall values: {}'.format(analysisResult[queryType]['score_std']))
         else:
             print('\n\n[Warning] {} as {} ID returned no association.'.format(analysisResult[queryType]['queryTerm'], queryType))
 


### PR DESCRIPTION
This branch has modifications to run disease and target specific searches at the same time and the output is printed out as requested:

1. Target/disease pairs for a target based search.
2. Target/disease pairs for a disease based search.
3. Association score stats for the target based search.
4. Association score stats for the disease based search.

As the query and the print statements are separated, the returned values needs to be stored and tracked. Also the script handles if only target or disease centric search is submitted.